### PR TITLE
add "Key Bindings" definitions for Interaction addon

### DIFF
--- a/Interaction/core.lua
+++ b/Interaction/core.lua
@@ -1,1 +1,3 @@
 --core.lua
+_G.BINDING_HEADER_INTERACTION = "Interaction"
+_G.BINDING_NAME_INTERACTIONKEYBIND = "Interaction Keybind"


### PR DESCRIPTION
bindings are missing definitions `<Binding name="INTERACTIONKEYBIND" header="INTERACTION" Category="ADDONS">`

<details>
<summary>
before screenshot:
</summary>

<img width="828" height="345" alt="before_interaction_keybind" src="https://github.com/user-attachments/assets/7a530c20-b7fd-404b-b05b-63a0c5cf5e1c" />

</details>



<details>
<summary>
after screenshot:
</summary>

<img width="831" height="688" alt="after_interaction_keybind" src="https://github.com/user-attachments/assets/1c728df8-3151-41eb-a2e5-283acbd7e2ae" />

</details>