### PR TITLE
fix case mismatch in include for NamePlates.h, remove cmake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 
+project(AwesomeWotlk)
+
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 set(CMAKE_SUPPRESS_REGENERATION ON)

--- a/src/AwesomeWotlkLib/UnitAPI.cpp
+++ b/src/AwesomeWotlkLib/UnitAPI.cpp
@@ -1,7 +1,7 @@
 #include "UnitAPI.h"
 #include "GameClient.h"
 #include "Hooks.h"
-#include "Nameplates.h"
+#include "NamePlates.h"
 
 extern int getTokenId(guid_t guid);
 


### PR DESCRIPTION
fixes compile error on Visual Studio 2022 "Cannot open include file: 'Nameplates.h': No such file or directory"
```
1> [CMake] -- The C compiler identification is MSVC 19.43.34810.0
1> [CMake] -- The CXX compiler identification is MSVC 19.43.34810.0
```

Warning due to missing project var
```
1> [CMake] CMake Warning (dev) in CMakeLists.txt:
1> [CMake]   No project() command is present.  The top-level CMakeLists.txt file must
1> [CMake]   contain a literal, direct call to the project() command.  Add a line of
1> [CMake]   code such as
1> [CMake] 
1> [CMake]     project(ProjectName)
1> [CMake] 
1> [CMake]   near the top of the file, but after cmake_minimum_required().
1> [CMake] 
```
