### PR TITLE
Feature: Add configurable interaction range

### DIFF
--- a/addons/AwesomeCVar/Constants.lua
+++ b/addons/AwesomeCVar/Constants.lua
@@ -58,6 +58,7 @@ ACVar.CVARS = {
     [L.CATEGORY_INTERACTION] = {
         { name = "interactionMode", label = L.CVAR_LABEL_INTERACTION_MODE, type = "mode", modes = { {value = 0, label = L.MODE_LABEL_PLAYER_RADIUS}, {value = 1, label = L.MODE_LABEL_CONE_ANGLE} } },
         { name = "interactionAngle", label = L.CVAR_LABEL_INTERACTION_ANGLE, type = "slider", min = 1, max = 360, step = 1, default = 90 },
+        { name = "interactionRange", label = L.CVAR_LABEL_INTERACTION_RANGE, type = "slider", min = 5, max = 30, step = 1, default = 20 },
     },
     [L.CATEGORY_OTHER] = {
         { name = "enableStancePatch", label = L.CVAR_ENABLE_STANCE_PATCH, desc = L.DESC_STANCE_PATCH, type = "toggle", min = 0, max = 1 },

--- a/addons/AwesomeCVar/Locales/deDE.lua
+++ b/addons/AwesomeCVar/Locales/deDE.lua
@@ -60,6 +60,7 @@ if GetLocale() == "deDE" then
     L.CVAR_LABEL_FRIENDLY_HITBOX_WIDTH = "FREUNDLICHE Namensplaketten Hitbox-Breite"
     L.CVAR_LABEL_INTERACTION_MODE = "Interaktionsmodus"
     L.CVAR_LABEL_INTERACTION_ANGLE = "Interaktionskegelwinkel"
+    L.CVAR_LABEL_INTERACTION_RANGE = "Interaktionsreichweite (yd)"
     L.CVAR_LABEL_EXTEND_WORLD_FRAME_HEIGHT = "World Frame Höhe erweitern"
     L.CVAR_ENABLE_STANCE_PATCH = "Stance/Form-Wechsel-Patch aktivieren"
     L.CVAR_LABEL_CAMERA_INDIRECT_VISIBILITY = "Indirekte Kamerasichtbarkeit"
@@ -75,6 +76,6 @@ if GetLocale() == "deDE" then
     -- CVar Mode Options
     L.MODE_LABEL_REACTION_API = "Reaktions-API"
     L.MODE_LABEL_COLOR_PARSING = "Farbanalyse"
-    L.MODE_LABEL_PLAYER_RADIUS = "Spielerradius 20yd"
-    L.MODE_LABEL_CONE_ANGLE = "Kegelwinkel (Grad) innerhalb von 20yd"
+    L.MODE_LABEL_PLAYER_RADIUS = "Spielerradius"
+    L.MODE_LABEL_CONE_ANGLE = "Kegelwinkel (Grad)"
 end

--- a/addons/AwesomeCVar/Locales/enUS.lua
+++ b/addons/AwesomeCVar/Locales/enUS.lua
@@ -60,6 +60,7 @@ if GetLocale() == "enUS" then
     L.CVAR_LABEL_FRIENDLY_HITBOX_WIDTH = "FRIENDLY Nameplate Hitbox Width"
     L.CVAR_LABEL_INTERACTION_MODE = "Interaction Mode"
     L.CVAR_LABEL_INTERACTION_ANGLE = "Interaction Cone Angle"
+    L.CVAR_LABEL_INTERACTION_RANGE = "Interaction Range (yd)"
     L.CVAR_LABEL_EXTEND_WORLD_FRAME_HEIGHT = "Extend World Frame Height"
     L.CVAR_LABEL_UPPER_BORDER_ONLY_BOSS = "Allow ONLY bosses to stick to upper border of the screen"
     L.CVAR_ENABLE_STANCE_PATCH = "Enable stance/form swap patch"
@@ -76,6 +77,6 @@ if GetLocale() == "enUS" then
     -- CVar Mode Options
     L.MODE_LABEL_REACTION_API = "Reaction API"
     L.MODE_LABEL_COLOR_PARSING = "Color Parsing"
-    L.MODE_LABEL_PLAYER_RADIUS = "Player Radius 20yd"
-    L.MODE_LABEL_CONE_ANGLE = "Cone Angle (dg) within 20yd"
+    L.MODE_LABEL_PLAYER_RADIUS = "Player Radius"
+    L.MODE_LABEL_CONE_ANGLE = "Cone Angle (dg)"
 end

--- a/addons/AwesomeCVar/Locales/esMX.lua
+++ b/addons/AwesomeCVar/Locales/esMX.lua
@@ -60,6 +60,7 @@ if GetLocale() == "esMX" then
     L.CVAR_LABEL_FRIENDLY_HITBOX_WIDTH = "Ancho del hitbox ALIADO"
     L.CVAR_LABEL_INTERACTION_MODE = "Modo de interacción"
     L.CVAR_LABEL_INTERACTION_ANGLE = "Ángulo del cono de interacción"
+    L.CVAR_LABEL_INTERACTION_RANGE = "Rango de interacción (yd)"
     L.CVAR_LABEL_EXTEND_WORLD_FRAME_HEIGHT = "Extender altura del World Frame"
     L.CVAR_ENABLE_STANCE_PATCH = "Activar parche de cambio de postura/forma"
     L.CVAR_LABEL_CAMERA_INDIRECT_VISIBILITY = "Visibilidad indirecta de la cámara"
@@ -75,6 +76,6 @@ if GetLocale() == "esMX" then
     -- CVar Mode Options
     L.MODE_LABEL_REACTION_API = "API de reacción"
     L.MODE_LABEL_COLOR_PARSING = "Análisis de color"
-    L.MODE_LABEL_PLAYER_RADIUS = "Radio del jugador 20yd"
-    L.MODE_LABEL_CONE_ANGLE = "Ángulo de cono (grados) dentro de 20yd"
+    L.MODE_LABEL_PLAYER_RADIUS = "Radio del jugador"
+    L.MODE_LABEL_CONE_ANGLE = "Ángulo de cono (grados)"
 end

--- a/addons/AwesomeCVar/Locales/frFR.lua
+++ b/addons/AwesomeCVar/Locales/frFR.lua
@@ -60,6 +60,7 @@ if GetLocale() == "frFR" then
     L.CVAR_LABEL_FRIENDLY_HITBOX_WIDTH = "Largeur de la hitbox AMICALE"
     L.CVAR_LABEL_INTERACTION_MODE = "Mode d'interaction"
     L.CVAR_LABEL_INTERACTION_ANGLE = "Angle du cône d'interaction"
+    L.CVAR_LABEL_INTERACTION_RANGE = "Portée d'interaction (m)"
     L.CVAR_LABEL_EXTEND_WORLD_FRAME_HEIGHT = "Étendre la hauteur du World Frame"
     L.CVAR_ENABLE_STANCE_PATCH = "Activer le patch de changement de posture/forme"
     L.CVAR_LABEL_CAMERA_INDIRECT_VISIBILITY = "Visibilité indirecte de la caméra"
@@ -75,6 +76,6 @@ if GetLocale() == "frFR" then
     -- CVar Mode Options
     L.MODE_LABEL_REACTION_API = "API de Réaction"
     L.MODE_LABEL_COLOR_PARSING = "Analyse de couleur"
-    L.MODE_LABEL_PLAYER_RADIUS = "Rayon du joueur 20m"
-    L.MODE_LABEL_CONE_ANGLE = "Angle du cône (dg) à moins de 20m"
+    L.MODE_LABEL_PLAYER_RADIUS = "Rayon du joueur"
+    L.MODE_LABEL_CONE_ANGLE = "Angle du cône (dg)"
 end

--- a/addons/AwesomeCVar/Locales/koKR.lua
+++ b/addons/AwesomeCVar/Locales/koKR.lua
@@ -60,6 +60,7 @@ if GetLocale() == "koKR" then
     L.CVAR_LABEL_FRIENDLY_HITBOX_WIDTH = "우호적 이름표 히트박스 너비"
     L.CVAR_LABEL_INTERACTION_MODE = "상호작용 모드"
     L.CVAR_LABEL_INTERACTION_ANGLE = "상호작용 원뿔 각도"
+    L.CVAR_LABEL_INTERACTION_RANGE = "상호작용 범위 (미터)"
     L.CVAR_LABEL_EXTEND_WORLD_FRAME_HEIGHT = "월드 프레임 높이 확장"
     L.CVAR_ENABLE_STANCE_PATCH = "태세/폼 전환 패치 활성화"
     L.CVAR_LABEL_CAMERA_INDIRECT_VISIBILITY = "카메라 간접 가시성"
@@ -75,6 +76,6 @@ if GetLocale() == "koKR" then
     -- CVar Mode Options
     L.MODE_LABEL_REACTION_API = "반응 API"
     L.MODE_LABEL_COLOR_PARSING = "색상 분석"
-    L.MODE_LABEL_PLAYER_RADIUS = "플레이어 반경 20미터"
-    L.MODE_LABEL_CONE_ANGLE = "20미터 내 원뿔 각도 (도)"
+    L.MODE_LABEL_PLAYER_RADIUS = "플레이어 반경"
+    L.MODE_LABEL_CONE_ANGLE = "원뿔 각도 (도)"
 end

--- a/addons/AwesomeCVar/Locales/ptBR.lua
+++ b/addons/AwesomeCVar/Locales/ptBR.lua
@@ -60,6 +60,7 @@ if GetLocale() == "ptBR" then
     L.CVAR_LABEL_FRIENDLY_HITBOX_WIDTH = "Largura da Hitbox ALIADA"
     L.CVAR_LABEL_INTERACTION_MODE = "Modo de Interação"
     L.CVAR_LABEL_INTERACTION_ANGLE = "Ângulo do Cone de Interação"
+    L.CVAR_LABEL_INTERACTION_RANGE = "Alcance de Interação (m)"
     L.CVAR_LABEL_EXTEND_WORLD_FRAME_HEIGHT = "Estender Altura do World Frame"
     L.CVAR_ENABLE_STANCE_PATCH = "Ativar patch de troca de postura/forma"
     L.CVAR_LABEL_CAMERA_INDIRECT_VISIBILITY = "Visibilidade Indireta da Câmera"
@@ -75,6 +76,6 @@ if GetLocale() == "ptBR" then
     -- CVar Mode Options
     L.MODE_LABEL_REACTION_API = "API de Reação"
     L.MODE_LABEL_COLOR_PARSING = "Análise de Cor"
-    L.MODE_LABEL_PLAYER_RADIUS = "Raio do Jogador 20m"
-    L.MODE_LABEL_CONE_ANGLE = "Ângulo do cone (graus) dentro de 20m"
+    L.MODE_LABEL_PLAYER_RADIUS = "Raio do Jogador"
+    L.MODE_LABEL_CONE_ANGLE = "Ângulo do cone (graus)"
 end

--- a/addons/AwesomeCVar/Locales/ruRU.lua
+++ b/addons/AwesomeCVar/Locales/ruRU.lua
@@ -60,6 +60,7 @@ if GetLocale() == "ruRU" then
     L.CVAR_LABEL_FRIENDLY_HITBOX_WIDTH = "Ширина хитбокса СОЮЗНИКОВ"
     L.CVAR_LABEL_INTERACTION_MODE = "Режим взаимодействия"
     L.CVAR_LABEL_INTERACTION_ANGLE = "Угол конуса взаимодействия"
+    L.CVAR_LABEL_INTERACTION_RANGE = "Дальность взаимодействия (м)"
     L.CVAR_LABEL_EXTEND_WORLD_FRAME_HEIGHT = "Увеличить высоту World Frame"
     L.CVAR_ENABLE_STANCE_PATCH = "Включить патч смены стойки/формы"
     L.CVAR_LABEL_CAMERA_INDIRECT_VISIBILITY = "Косвенная видимость камеры"
@@ -75,6 +76,6 @@ if GetLocale() == "ruRU" then
     -- CVar Mode Options
     L.MODE_LABEL_REACTION_API = "API реакции"
     L.MODE_LABEL_COLOR_PARSING = "Анализ цвета"
-    L.MODE_LABEL_PLAYER_RADIUS = "Радиус игрока 20м"
-    L.MODE_LABEL_CONE_ANGLE = "Угол конуса (в градусах) в пределах 20м"
+    L.MODE_LABEL_PLAYER_RADIUS = "Радиус игрока"
+    L.MODE_LABEL_CONE_ANGLE = "Угол конуса (в градусах)"
 end

--- a/addons/AwesomeCVar/Locales/zhCN.lua
+++ b/addons/AwesomeCVar/Locales/zhCN.lua
@@ -60,6 +60,7 @@ if GetLocale() == "zhCN" then
     L.CVAR_LABEL_FRIENDLY_HITBOX_WIDTH = "友方姓名板点击框宽度"
     L.CVAR_LABEL_INTERACTION_MODE = "互动模式"
     L.CVAR_LABEL_INTERACTION_ANGLE = "互动锥形角度"
+    L.CVAR_LABEL_INTERACTION_RANGE = "互动范围 (码)"
     L.CVAR_LABEL_EXTEND_WORLD_FRAME_HEIGHT = "扩展世界框架高度"
     L.CVAR_ENABLE_STANCE_PATCH = "启用姿态/形态切换补丁"
     L.CVAR_LABEL_CAMERA_INDIRECT_VISIBILITY = "镜头间接可见性"
@@ -75,6 +76,6 @@ if GetLocale() == "zhCN" then
     -- CVar Mode Options
     L.MODE_LABEL_REACTION_API = "反应 API"
     L.MODE_LABEL_COLOR_PARSING = "颜色解析"
-    L.MODE_LABEL_PLAYER_RADIUS = "玩家半径 20 码"
-    L.MODE_LABEL_CONE_ANGLE = "20 码内锥形角度（度）"
+    L.MODE_LABEL_PLAYER_RADIUS = "玩家半径"
+    L.MODE_LABEL_CONE_ANGLE = "锥形角度（度）"
 end

--- a/addons/AwesomeCVar/Locales/zhTW.lua
+++ b/addons/AwesomeCVar/Locales/zhTW.lua
@@ -60,6 +60,7 @@ if GetLocale() == "zhTW" then
     L.CVAR_LABEL_FRIENDLY_HITBOX_WIDTH = "友方姓名板點擊框寬度"
     L.CVAR_LABEL_INTERACTION_MODE = "互動模式"
     L.CVAR_LABEL_INTERACTION_ANGLE = "互動錐形角度"
+    L.CVAR_LABEL_INTERACTION_RANGE = "互動範圍 (碼)"
     L.CVAR_LABEL_EXTEND_WORLD_FRAME_HEIGHT = "延展世界框架高度"
     L.CVAR_ENABLE_STANCE_PATCH = "啟用姿態/形態切換修補"
     L.CVAR_LABEL_CAMERA_INDIRECT_VISIBILITY = "鏡頭間接可見性"
@@ -75,6 +76,6 @@ if GetLocale() == "zhTW" then
     -- CVar Mode Options
     L.MODE_LABEL_REACTION_API = "反應 API"
     L.MODE_LABEL_COLOR_PARSING = "顏色解析"
-    L.MODE_LABEL_PLAYER_RADIUS = "玩家半徑 20 碼"
-    L.MODE_LABEL_CONE_ANGLE = "20 碼內錐形角度（度）"
+    L.MODE_LABEL_PLAYER_RADIUS = "玩家半徑"
+    L.MODE_LABEL_CONE_ANGLE = "錐形角度（度）"
 end

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -311,9 +311,9 @@ Arguments: **mode**`bool`
 
 Default: **1**
 
-Toggles behaviour of interaction keybind, or macro. <br>
-If set to **1**, interaction is limited to entities located in front of the player within the angle defined by the `interactionAngle` CVar and within 20 yards.<br>
-If set to **0**, interaction will occur with the nearest entity within 20 yards of the player, regardless of its direction.
+Toggles the behaviour of the interaction keybind or macro. <br>
+If set to **1**, interaction is limited to entities located in front of the player within the angle defined by the `interactionAngle` CVar and within the range defined by the `interactionRange` CVar. <br>
+If set to **0**, interaction will occur with the nearest entity within the range defined by `interactionRange`, regardless of its direction.
 
 ## interactionAngle`CVar` 
 Arguments: **angle**`number`
@@ -321,7 +321,16 @@ Arguments: **angle**`number`
 Default: **60**
 
 The size of the cone-shaped area in front of the player (measured in degrees) within which a mob or entity must be located to be eligible for interaction. <br>
-This is only used if `interactionMode` is set to 1, which is the default.
+This is only used if `interactionMode` is set to **1**, which is the default.
+
+## interactionRange`CVar`
+Arguments: **range**`number`
+
+Default: **20**
+
+Limited to [5 – 30] range.
+
+Controls the maximum distance (in yards) within which the interaction will look for eligible entities or objects.
 
 ## Cursor`macro`
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -53,6 +53,7 @@ ___
     - nameplateFriendlyHitboxWidth<br>
     - interactionMode<br>
     - interactionAngle<br>
+    - interactionRange<br>
     - nameplateStackFriendly<br>
     - nameplateStackFriendlyMode<br>
     - nameplateMaxRaiseDistance<br>


### PR DESCRIPTION
- Adds a new CVar (`interactionRange`) to control the maximum range for interaction lookups.
- Defaults to the original fixed range of 20yd; minimum 5yd, maximum 30yd.
- Useful for tighter control when using Click-to-Move, for example in dungeon or other group settings.