### PR TITLE
Bugfix: Wrong default fov in options gui

### DIFF
--- a/addons/AwesomeCVar/Constants.lua
+++ b/addons/AwesomeCVar/Constants.lua
@@ -31,7 +31,7 @@ ACVar.CONSTANTS = {
 -- This table defines every CVar control that will appear in the UI.
 ACVar.CVARS = {
     [L.CATEGORY_CAMERA] = {
-        { name = "cameraFov", label = L.CVAR_LABEL_CAMERA_FOV, type = "slider", min = 30, max = 150, default = 90 },
+        { name = "cameraFov", label = L.CVAR_LABEL_CAMERA_FOV, type = "slider", min = 30, max = 150, default = 100 },
         { name = "cameraIndirectVisibility", label = L.CVAR_LABEL_CAMERA_INDIRECT_VISIBILITY, desc = L.DESC_CAMERA_INDIRECT_VISIBILITY, type = "toggle", min = 0, max = 1 },
         { name = "cameraIndirectAlpha", label = L.CVAR_LABEL_CAMERA_INDIRECT_ALPHA, desc = L.DESC_CAMERA_INDIRECT_ALPHA, type = "slider", min = 0.6, max = 1, step = 0.05, default = 0.6 },
     },

--- a/addons/AwesomeCVar/Constants.lua
+++ b/addons/AwesomeCVar/Constants.lua
@@ -31,7 +31,7 @@ ACVar.CONSTANTS = {
 -- This table defines every CVar control that will appear in the UI.
 ACVar.CVARS = {
     [L.CATEGORY_CAMERA] = {
-        { name = "cameraFov", label = L.CVAR_LABEL_CAMERA_FOV, type = "slider", min = 30, max = 150, default = 100 },
+        { name = "cameraFov", label = L.CVAR_LABEL_CAMERA_FOV, type = "slider", min = 30, max = 200, default = 100 },
         { name = "cameraIndirectVisibility", label = L.CVAR_LABEL_CAMERA_INDIRECT_VISIBILITY, desc = L.DESC_CAMERA_INDIRECT_VISIBILITY, type = "toggle", min = 0, max = 1 },
         { name = "cameraIndirectAlpha", label = L.CVAR_LABEL_CAMERA_INDIRECT_ALPHA, desc = L.DESC_CAMERA_INDIRECT_ALPHA, type = "slider", min = 0.6, max = 1, step = 0.05, default = 0.6 },
     },

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -364,7 +364,7 @@ Returns: `none`
 Copies text to clipboard
 
 ## cameraFov`CVar`
-Parameters: **value**`number`
+Arguments: **value**`number`
 
 Default: **100**
 


### PR DESCRIPTION
- Options GUI corrected the default fov to 100 instead of 90
- Updated cameraFov Doc
- Options GUI fov max value increased to the CVars max of 200